### PR TITLE
cbm: disable afbc in the kernel directly

### DIFF
--- a/misc.cbm/patches/v6.12/mt81xx-disable-afbc.patch
+++ b/misc.cbm/patches/v6.12/mt81xx-disable-afbc.patch
@@ -1,0 +1,28 @@
+based on https://gitlab.collabora.com/mediatek/aiot/linux/-/commit/8f40003af37e1567e53fdfcb6446ab4b90755bc0
+
+diff --git a/drivers/gpu/drm/mediatek/mtk_plane.c b/drivers/gpu/drm/mediatek/mtk_plane.c
+index 6e20f7037b5b..5a14ed3d4a74 100644
+--- a/drivers/gpu/drm/mediatek/mtk_plane.c
++++ b/drivers/gpu/drm/mediatek/mtk_plane.c
+@@ -21,9 +21,11 @@
+ 
+ static const u64 modifiers[] = {
+ 	DRM_FORMAT_MOD_LINEAR,
++	/* HACK disable AFBC support for now
+ 	DRM_FORMAT_MOD_ARM_AFBC(AFBC_FORMAT_MOD_BLOCK_SIZE_32x8 |
+ 				AFBC_FORMAT_MOD_SPLIT |
+ 				AFBC_FORMAT_MOD_SPARSE),
++				*/
+ 	DRM_FORMAT_MOD_INVALID,
+ };
+ 
+@@ -74,6 +76,9 @@ static bool mtk_plane_format_mod_supported(struct drm_plane *plane,
+ 	if (modifier == DRM_FORMAT_MOD_LINEAR)
+ 		return true;
+ 
++	/* HACK: Disable AFBC support for all planes */
++	return false;
++
+ 	if (modifier != DRM_FORMAT_MOD_ARM_AFBC(
+ 				AFBC_FORMAT_MOD_BLOCK_SIZE_32x8 |
+ 				AFBC_FORMAT_MOD_SPLIT |

--- a/readme.cbm
+++ b/readme.cbm
@@ -41,6 +41,12 @@ done
 #  patch -p1 < $i
 #done
 
+# patches for all mt81xx devices
+for i in /compile/doc/stable-mt/misc.cbm/patches/v6.12/mt81xx*.patch; do
+  echo === $i
+  patch -p1 < $i
+done
+
 # remove panfrost purge log spam
 patch -p1 < /compile/doc/kernel-extra-patches/remove-panfrost-purge-log-spam/v6.12.12.patch
 # fix kernel version number: + instead of -dirty at the end


### PR DESCRIPTION
afbc (arm frame buffer compression) seems to be broken on either mediatek devices or even in general on gpus handled by the panfrost driver in v6.12 so this hack will disable it in the kernel