### PR TITLE
cbm,mt7,mt8,mt9,mtx: remove default ipv6 disable, add cmdline

### DIFF
--- a/misc.cbm/misc/cmdline
+++ b/misc.cbm/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 noresume apparmor=0
+console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0

--- a/misc.mt9/misc/cmdline
+++ b/misc.mt9/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 noresume apparmor=0
+console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0

--- a/misc.mtx/misc/cmdline
+++ b/misc.mtx/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 noresume apparmor=0
+console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0

--- a/readme.cbm
+++ b/readme.cbm
@@ -85,6 +85,7 @@ cp -v arch/arm64/boot/dts/mediatek/mt8186-corsola-*.dtb /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/mediatek/mt8192-asurada-*.dtb /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/mediatek/mt8195-cherry-*.dtb /boot/dtb-${kver}
 cp -v System.map /boot/System.map-${kver}
+echo "console=tty1 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 quiet splash" > /boot/cmdline-${kver}
 # start chromebook special - required: apt-get install liblz4-tool vboot-kernel-utils
 cp arch/arm64/boot/Image Image
 lz4 -f Image Image.lz4
@@ -98,7 +99,7 @@ rm -f Image Image.lz4 cmdline bootloader.bin kernel.itb vmlinux.kpart
 cd /boot
 update-initramfs -c -k ${kver}
 #mkimage -A arm64 -O linux -T ramdisk -a 0x0 -e 0x0 -n initrd.img-${kver} -d initrd.img-${kver} uInitrd-${kver}
-tar cvzf /compile/source/linux-stable-cbm/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
+tar cvzf /compile/source/linux-stable-cbm/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/cmdline-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
 cp -v /compile/doc/stable-mt/config.cbm /compile/doc/stable-mt/config.cbm.old
 cp -v /compile/source/linux-stable-cbm/.config /compile/doc/stable-mt/config.cbm
 cp -v /compile/source/linux-stable-cbm/.config /compile/doc/stable-mt/config.cbm-${kver}

--- a/readme.mt7
+++ b/readme.mt7
@@ -54,6 +54,7 @@ cp -v arch/arm64/boot/Image /boot/Image-${kver}
 mkdir -p /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/mediatek/mt8173*.dtb /boot/dtb-${kver}
 cp -v System.map /boot/System.map-${kver}
+echo "console=tty1 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 quiet splash" > /boot/cmdline-${kver}
 # start chromebook special - required: apt-get install liblz4-tool vboot-kernel-utils
 cp arch/arm64/boot/Image Image
 lz4 -f Image Image.lz4
@@ -67,7 +68,7 @@ rm -f Image Image.lz4 cmdline bootloader.bin kernel.itb vmlinux.kpart
 cd /boot
 update-initramfs -c -k ${kver}
 #mkimage -A arm64 -O linux -T ramdisk -a 0x0 -e 0x0 -n initrd.img-${kver} -d initrd.img-${kver} uInitrd-${kver}
-tar cvzf /compile/source/linux-stable-mt7/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
+tar cvzf /compile/source/linux-stable-mt7/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/cmdline-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
 cp -v /compile/doc/stable-mt/config.mt7 /compile/doc/stable-mt/config.mt7.old
 cp -v /compile/source/linux-stable-mt7/.config /compile/doc/stable-mt/config.mt7
 cp -v /compile/source/linux-stable-mt7/.config /compile/doc/stable-mt/config.mt7-${kver}

--- a/readme.mt8
+++ b/readme.mt8
@@ -54,6 +54,7 @@ cp -v arch/arm64/boot/Image /boot/Image-${kver}
 mkdir -p /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/mediatek/mt8183*.dtb /boot/dtb-${kver}
 cp -v System.map /boot/System.map-${kver}
+echo "console=tty1 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 quiet splash" > /boot/cmdline-${kver}
 # start chromebook special - required: apt-get install liblz4-tool vboot-kernel-utils
 cp arch/arm64/boot/Image Image
 lz4 -f Image Image.lz4
@@ -67,7 +68,7 @@ rm -f Image Image.lz4 cmdline bootloader.bin kernel.itb vmlinux.kpart
 cd /boot
 update-initramfs -c -k ${kver}
 #mkimage -A arm64 -O linux -T ramdisk -a 0x0 -e 0x0 -n initrd.img-${kver} -d initrd.img-${kver} uInitrd-${kver}
-tar cvzf /compile/source/linux-stable-mt8/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
+tar cvzf /compile/source/linux-stable-mt8/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/cmdline-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
 cp -v /compile/doc/stable-mt/config.mt8 /compile/doc/stable-mt/config.mt8.old
 cp -v /compile/source/linux-stable-mt8/.config /compile/doc/stable-mt/config.mt8
 cp -v /compile/source/linux-stable-mt8/.config /compile/doc/stable-mt/config.mt8-${kver}

--- a/readme.mt9
+++ b/readme.mt9
@@ -46,6 +46,7 @@ cp -v arch/arm64/boot/dts/mediatek/mt817*.dtb /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/mediatek/mt818*.dtb /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/mediatek/mt819*.dtb /boot/dtb-${kver}
 cp -v System.map /boot/System.map-${kver}
+echo "console=tty1 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 quiet splash" > /boot/cmdline-${kver}
 # start chromebook special - required: apt-get install liblz4-tool vboot-kernel-utils
 cp arch/arm64/boot/Image Image
 lz4 -f Image Image.lz4
@@ -59,7 +60,7 @@ rm -f Image Image.lz4 cmdline bootloader.bin kernel.itb vmlinux.kpart
 cd /boot
 update-initramfs -c -k ${kver}
 #mkimage -A arm64 -O linux -T ramdisk -a 0x0 -e 0x0 -n initrd.img-${kver} -d initrd.img-${kver} uInitrd-${kver}
-tar cvzf /compile/source/linux-stable-mt9/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
+tar cvzf /compile/source/linux-stable-mt9/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/cmdline-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
 cp -v /compile/doc/stable-mt/config.mt9 /compile/doc/stable-mt/config.mt9.old
 cp -v /compile/source/linux-stable-mt9/.config /compile/doc/stable-mt/config.mt9
 cp -v /compile/source/linux-stable-mt9/.config /compile/doc/stable-mt/config.mt9-${kver}

--- a/readme.mtx
+++ b/readme.mtx
@@ -49,6 +49,7 @@ cp -v arch/arm64/boot/dts/mediatek/mt817*.dtb /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/mediatek/mt818*.dtb /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/mediatek/mt819*.dtb /boot/dtb-${kver}
 cp -v System.map /boot/System.map-${kver}
+echo "console=tty1 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 quiet splash" > /boot/cmdline-${kver}
 # start chromebook special - required: apt-get install liblz4-tool vboot-kernel-utils
 cp arch/arm64/boot/Image Image
 lz4 -f Image Image.lz4
@@ -62,7 +63,7 @@ rm -f Image Image.lz4 cmdline bootloader.bin kernel.itb vmlinux.kpart
 cd /boot
 update-initramfs -c -k ${kver}
 #mkimage -A arm64 -O linux -T ramdisk -a 0x0 -e 0x0 -n initrd.img-${kver} -d initrd.img-${kver} uInitrd-${kver}
-tar cvzf /compile/source/linux-stable-mtx/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
+tar cvzf /compile/source/linux-stable-mtx/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/cmdline-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
 cp -v /compile/doc/stable-mt/config.mtx /compile/doc/stable-mt/config.mtx.old
 cp -v /compile/source/linux-stable-mtx/.config /compile/doc/stable-mt/config.mtx
 cp -v /compile/source/linux-stable-mtx/.config /compile/doc/stable-mt/config.mtx-${kver}


### PR DESCRIPTION
better no longer turn off ipv6 by default as nowadays its required in some cases and some things like waydroid may run into trouble if ipv6 is disabled

while at the cmdline already: also add the creation and addition of the cmdline-kernel-version file for the chromebook kernels managed by the velvet-tools